### PR TITLE
Enable CAN FIFO Transmit priority

### DIFF
--- a/src/can.c
+++ b/src/can.c
@@ -76,7 +76,7 @@ void can_enable(void)
     	can_handle.Init.AutoWakeUp = DISABLE;
     	can_handle.Init.AutoRetransmission = can_autoretransmit;
     	can_handle.Init.ReceiveFifoLocked = DISABLE;
-    	can_handle.Init.TransmitFifoPriority = DISABLE;
+    	can_handle.Init.TransmitFifoPriority = ENABLE;
         HAL_CAN_Init(&can_handle);
 
         HAL_CAN_ConfigFilter(&can_handle, &filter);


### PR DESCRIPTION
First of all, I'd like to complement you on the organization of this firmware. Super easy to read and modify, well done!

The last commit adding buffering has really improved performance, however one last change was required for my application. We're using ISO 15675-2 (ISO-TP), which relies on the ordering of messages. To ensure the messages are sent over the bus in the same order we send them to the CANable, I enabled the FIFO transmit priority.

(Adapted from the STM32 manual, section 29.7.1):

When FIFO transmit priority is disabled and when more than one transmit mailbox is pending, the transmission order is given by the identifier of the message stored in the mailbox. The message with the lowest identifier value has the highest priority according to the arbitration of the CAN protocol. If the identifier values are equal, the lower mailbox number will be scheduled first.

The transmit mailboxes can be configured as a transmit FIFO by setting the TXFP bit in theCAN_MCR register. In this mode the priority order is given by the transmit request order.
This mode is very useful for segmented transmission.

With this change, things are working well even with a good amount of load on the bus. Let me know if you have any questions! Thanks for maintaining this great project!